### PR TITLE
feat: Add the multidimensional case for sub2ind

### DIFF
--- a/aimt.h
+++ b/aimt.h
@@ -2,3 +2,18 @@ void ind2sub2D(const int *arrayOfDimensions, const int index, int convertedIndex
 	convertedIndex[1] = index % arrayOfDimensions[1];
 	convertedIndex[0] = index / arrayOfDimensions[1];
 }
+
+void ind2sub(const int *arrayOfDimensions, const int arraySize, const int index, int convertedIndex[]){  
+	int subscript = arraySize - 1;
+	if(subscript < 2){
+		ind2sub2D(arrayOfDimensions, index, convertedIndex);
+	}else{
+		int hypoDimensionsProduct = 1;
+		for(int i = 0; i < subscript; i++){
+			hypoDimensionsProduct *= arrayOfDimensions[i];
+		}
+		convertedIndex[subscript] = index / hypoDimensionsProduct;	
+		int newIndex = index % hypoDimensionsProduct;
+		ind2sub(arrayOfDimensions, subscript, newIndex, convertedIndex);
+	}
+}

--- a/demo/demo_2DArray.c
+++ b/demo/demo_2DArray.c
@@ -1,0 +1,33 @@
+#include <stdio.h>
+#include "../aimt.h"
+
+/* 
+
+3x5 array filled with its indexes in 
+each respective position.
+
+ 0  1  2  3  4
+ 5  6  7  8  9
+10 11 12 13 14
+
+*/
+
+int main(){
+	// array with 3 rows and 5 columns.
+	int arr[] = {3, 5};
+
+	// index to be converted.
+	int index = 8;
+	
+	// subscripts.
+	int sub[2];
+	ind2sub2D(arr, index, sub);
+
+	printf("The linear index %d was converted"
+	       " to subscripts (%d, %d) of a %dx%d"
+	       " array.", index, sub[0], sub[1], 
+	       arr[0], arr[1]);
+
+	return 0;
+}
+

--- a/demo/demo_3DArray.c
+++ b/demo/demo_3DArray.c
@@ -1,0 +1,48 @@
+#include <stdio.h>
+#include "../aimt.h"
+
+/* 
+
+3x5x4 array sections filled with its 
+indexes in each respective position.
+
+dim3 = 0
+ 0  1  2  3  4
+ 5  6  7  8  9
+10 11 12 13 14
+
+dim3 = 1
+15 16 17 18 19
+20 21 22 23 24
+25 26 27 28 29
+
+dim3 = 2
+30 31 32 33 34
+35 36 37 38 39
+40 41 42 43 44
+
+dim3 = 3
+45 46 47 48 49
+50 51 52 53 54
+55 56 57 58 59
+
+*/
+
+int main(){
+
+	int arr[] = {3, 5, 4};
+	int index = 38;
+
+	int size = sizeof(arr)/sizeof(arr[0]);
+
+	int sub[size];
+	ind2sub(arr, size, index, sub);
+
+	printf("The linear index %d was converted"
+	       " to subscripts (%d, %d, %d) of a"
+	       " %dx%dx%d array.", index, sub[0], 
+	       sub[1], sub[2], arr[0], arr[1], 
+	       arr[2]);
+		       
+	return 0;
+}


### PR DESCRIPTION
The new sub2ind function is for cases of order two or higher. It
calculates all the indices iteratively, from the highest to the lowest,
until it reaches the first two indices. When this occurs, the function
calls sub2ind2d again.

- The "ArrayOfDimensions" is an input that holds the number of elements
in the two dimensions of this array. The "arraySize" is an input that
represents the number of dimensions of our array.
- The "index" input represents the linear index to be converted.
- And the "convertedIndex" is an array containing both subscripts.
The first is the row, and the second is the column.

See the demo/demo_3DArray.c file for more details.