### PR TITLE
Add error messages

### DIFF
--- a/aimt.h
+++ b/aimt.h
@@ -1,3 +1,6 @@
+#include <stdlib.h>
+#include <stdio.h>
+
 int calculateHypoDimensionsProduct(const int *arrayOfDimensions, const int indexPosition){
 	int hypoDimensionsProduct = 1;
 	for(int i = 0; i < indexPosition; i++){
@@ -6,11 +9,50 @@ int calculateHypoDimensionsProduct(const int *arrayOfDimensions, const int index
 	return hypoDimensionsProduct;
 }
 
+void callErrorMessage(int errorNumber){
+switch(errorNumber){
+		case 1:
+		    printf("ERROR: The subscripts provide must be contained within a valid bound.");
+		    break;
+		case 2:
+		    printf("ERROR: The index provide must be contained within a valid bound.");
+		    break;
+		default:
+		    printf("Unknown error");
+	}
+}
+
+int isValidArrayOfSubscripts(const int *arrayOfDimensions, const int *arrayOfSubscripts, const int arraySize){
+	for(int i = 0; i < arraySize; i++){
+		if(arrayOfSubscripts[i] < 0 || arrayOfSubscripts[i] >= arrayOfDimensions[i]){
+			return 0;
+		}
+	}
+	return 1;
+}
+
+int isValidIndex(const int *arrayOfDimensions, const int index, const int arraySize){
+	int maxValue = calculateHypoDimensionsProduct(arrayOfDimensions, arraySize) - 1;
+	if(index < 0 || index > maxValue){
+		return 0;
+	}
+	return 1;
+}
+
 int sub2ind2D(const int *arrayOfDimensions, const int *arrayOfSubscripts){
-	return arrayOfSubscripts[0] * arrayOfDimensions[1] + arrayOfSubscripts[1];	
+	if(!isValidArrayOfSubscripts(arrayOfDimensions, arrayOfSubscripts, 2)){
+		callErrorMessage(1);
+		exit(EXIT_FAILURE);
+	}
+	int subscript = arrayOfSubscripts[0] * arrayOfDimensions[1] + arrayOfSubscripts[1];
+	return subscript;
 }
 
 int sub2ind(const int *arrayOfDimensions, const int *arrayOfSubscripts, const int arraySize){
+	if(!isValidArrayOfSubscripts(arrayOfDimensions, arrayOfSubscripts, arraySize)){
+		callErrorMessage(1);
+		exit(EXIT_FAILURE);
+	}
 	int subscript = arraySize - 1;
 	int value = 0;
 	value += sub2ind2D(arrayOfDimensions, arrayOfSubscripts);  
@@ -24,11 +66,19 @@ int sub2ind(const int *arrayOfDimensions, const int *arrayOfSubscripts, const in
 }
 
 void ind2sub2D(const int *arrayOfDimensions, const int index, int convertedIndex[]){
+	if(!isValidIndex(arrayOfDimensions, index, 2)){
+		callErrorMessage(2);
+		exit(EXIT_FAILURE);
+	}
 	convertedIndex[1] = index % arrayOfDimensions[1];
 	convertedIndex[0] = index / arrayOfDimensions[1];
 }
 
 void ind2sub(const int *arrayOfDimensions, const int arraySize, const int index, int convertedIndex[]){  
+	if(!isValidIndex(arrayOfDimensions, index, arraySize)){
+		callErrorMessage(2);
+		exit(EXIT_FAILURE);
+	}
 	int subscript = arraySize - 1;
 	if(subscript < 2){
 		ind2sub2D(arrayOfDimensions, index, convertedIndex);


### PR DESCRIPTION
All conversion functions require caution when entering inputs. However,
there is nothing to prevent them from returning false results. I fixed this.