### PR TITLE
refac: Adding a tab spacing

### DIFF
--- a/aimt.h
+++ b/aimt.h
@@ -10,7 +10,7 @@ int calculateDimensionsProduct(const int *arrayOfDimensions, const int subscript
 }
 
 void callErrorMessage(int errorNumber){
-switch(errorNumber){
+	switch(errorNumber){
 		case 1:
 		    printf("ERROR: The subscripts provide must be contained within a valid bound.");
 		    break;


### PR DESCRIPTION
I just inserted a tab spacing inside the "callErrorMessage" function to
make the code easier to read.