### PR TITLE
implements bug fix for return value

### DIFF
--- a/src/aimt.c
+++ b/src/aimt.c
@@ -1,9 +1,9 @@
 #include "aimt.h"
 
-int sub2ind(const int *arrayOfDimensions, const int *arrayOfSubscripts, const int dimensions){
+long long sub2ind(const int *arrayOfDimensions, const int *arrayOfSubscripts, const int dimensions){
 	inspectSubscripts(arrayOfDimensions, arrayOfSubscripts, dimensions);
 	int subscriptPosition = dimensions - 1;
-	int value = 1;
+	long long value = 1;
 	for(int i = subscriptPosition; i >= 0; i--){
 		int hypoDimensionsProduct = calculateDimensionsProduct(arrayOfDimensions, i);
 		value += (arrayOfSubscripts[i] - 1) * hypoDimensionsProduct; 

--- a/src/aimt.h
+++ b/src/aimt.h
@@ -23,7 +23,7 @@
  * @warning Ensure that @paramname{arrayOfDimensions} and @paramname{arrayOfSubscripts} 
  * share the same @paramname{dimension}, in order to get a proper result.
  */
-int sub2ind(const int *arrayOfDimensions, const int *arrayOfSubscripts, const int dimensions);
+long long sub2ind(const int *arrayOfDimensions, const int *arrayOfSubscripts, const int dimensions);
 
 /** 
  *


### PR DESCRIPTION
Changing return value of sub2int from int to long long to avoid possible integer buffer overflow.
Please advise if anything further is needed.
Thanks,
Carlton