### PR TITLE
fix: Add the file and line when error appears

### DIFF
--- a/src/aimt.c
+++ b/src/aimt.c
@@ -1,7 +1,6 @@
 #include "aimt.h"
 
-long long sub2ind(const int *arrayOfDimensions, const int *arrayOfSubscripts, const int dimensions){
-	inspectSubscripts(arrayOfDimensions, arrayOfSubscripts, dimensions);
+long long Isub2ind(const int *arrayOfDimensions, const int *arrayOfSubscripts, const int dimensions){
 	int subscriptPosition = dimensions - 1;
 	long long value = 1;
 	for(int i = subscriptPosition; i >= 0; i--){
@@ -11,8 +10,7 @@ long long sub2ind(const int *arrayOfDimensions, const int *arrayOfSubscripts, co
 	return value;
 }
 
-void ind2sub(const int *arrayOfDimensions, const int dimensions, const int index, int convertedIndex[]){
-	inspectIndex(arrayOfDimensions, index, dimensions);
+void Iind2sub(const int *arrayOfDimensions, const int dimensions, const int index, int convertedIndex[]){
 	int subscriptPosition = dimensions - 1;
 	if(subscriptPosition >= 0){
 		int hypoDimensionsProduct = calculateDimensionsProduct(arrayOfDimensions, subscriptPosition);

--- a/src/aimt.h
+++ b/src/aimt.h
@@ -4,6 +4,16 @@
 #include "errorsHandler.h"
 #include "dimensionsProduct.h"
 
+#define sub2ind(arrayOfDimensions, arrayOfSubscripts, dimensions) ({ \
+	inspectSubscripts(__FILE__, __LINE__, arrayOfDimensions, arrayOfSubscripts, dimensions); \
+	Isub2ind(arrayOfDimensions, arrayOfSubscripts, dimensions); \
+})
+
+#define ind2sub(arrayOfDimensions, dimensions, index, convertedIndex) ({ \
+	inspectIndex(__FILE__, __LINE__, arrayOfDimensions, index, dimensions); \
+	Iind2sub(arrayOfDimensions, dimensions, index, convertedIndex); \
+})
+
 /**
  *
  * @brief Converts subscripts into linear indices. The linear index traverses rows, 
@@ -23,7 +33,7 @@
  * @warning Ensure that @paramname{arrayOfDimensions} and @paramname{arrayOfSubscripts} 
  * share the same @paramname{dimension}, in order to get a proper result.
  */
-long long sub2ind(const int *arrayOfDimensions, const int *arrayOfSubscripts, const int dimensions);
+long long Isub2ind(const int *arrayOfDimensions, const int *arrayOfSubscripts, const int dimensions);
 
 /** 
  *
@@ -49,7 +59,7 @@ long long sub2ind(const int *arrayOfDimensions, const int *arrayOfSubscripts, co
  * @warning Ensure that @paramname{arrayOfDimensions} and @paramname{arrayOfSubscripts} 
  * share the same @paramname{dimension}, in order to get a proper result.
  */
-void ind2sub(const int *arrayOfDimensions, const int dimensions, const int index, int convertedIndex[]);
+void Iind2sub(const int *arrayOfDimensions, const int dimensions, const int index, int convertedIndex[]);
 
 /** 
  *

--- a/src/errorsHandler.c
+++ b/src/errorsHandler.c
@@ -1,12 +1,12 @@
 #include "errorsHandler.h"
 
-void callErrorMessage(int errorNumber){
+void callErrorMessage(int errorNumber, const char *fileName, const int codeLine){
 	switch(errorNumber){
 		case 1:
-		    printf("ERROR: The subscripts provide must be contained within a valid bound.");
+		    printf("Error from sub2ind function at %s:%d -- The subscripts provide must be contained within a valid bound.", fileName, codeLine);
 		    break;
 		case 2:
-		    printf("ERROR: The index provide must be contained within a valid bound.");
+		    printf("Error from ind2sub function at %s:%d -- The index provide must be contained within a valid bound.", fileName, codeLine);
 		    break;
 		default:
 		    printf("Unknown error");
@@ -30,16 +30,16 @@ int isValidIndex(const int *arrayOfDimensions, const int index, const int dimens
 	return 1;
 }
 
-void inspectSubscripts(const int *arrayOfDimensions, const int *arrayOfSubscripts, const int dimensions){
+void inspectSubscripts(const char *fileName, const int codeLine, const int *arrayOfDimensions, const int *arrayOfSubscripts, const int dimensions){
 	if(!isValidArrayOfSubscripts(arrayOfDimensions, arrayOfSubscripts, dimensions)){
-		callErrorMessage(1);
+		callErrorMessage(1, fileName, codeLine);
 		exit(EXIT_FAILURE);
 	}
 }
 
-void inspectIndex(int const *arrayOfDimensions, int const index, int const dimension){
+void inspectIndex(const char *fileName, const int codeLine, int const *arrayOfDimensions, int const index, int const dimension){
 	if(!isValidIndex(arrayOfDimensions, index, dimension)){
-		callErrorMessage(2);
+		callErrorMessage(2, fileName, codeLine);
 		exit(EXIT_FAILURE);
 	}
 }

--- a/src/errorsHandler.h
+++ b/src/errorsHandler.h
@@ -5,10 +5,10 @@
 #include <stdio.h>
 #include "dimensionsProduct.h"
 
-void callErrorMessage(int errorNumber);
+void callErrorMessage(int errorNumber, const char *fileName, const int line);
 int isValidArrayOfSubscripts(const int *arrayOfDimensions, const int *arrayOfSubscripts, const int dimensions);
 int isValidIndex(const int *arrayOfDimensions, const int index, const int dimensions);
-void inspectSubscripts(const int *arrayOfDimensions, const int *arrayOfSubscripts, const int dimensions);
-void inspectIndex(int const *arrayOfDimensions, int const index, int const dimension);
+void inspectSubscripts(const char *fileName, const int codeLine, const int *arrayOfDimensions, const int *arrayOfSubscripts, const int dimensions);
+void inspectIndex(const char *fileName, const int codeLine, int const *arrayOfDimensions, int const index, int const dimension);
 
 #endif


### PR DESCRIPTION
In this new version, I made the error message indicate the file and the
line when the sub2ind and ind2sub functions are used inappropriately.
This change tells the user what is going on.

This pull request closes #33