### PR TITLE
docs: Fixing documentation

### DIFF
--- a/docs/doxygenConfig
+++ b/docs/doxygenConfig
@@ -44,7 +44,7 @@ PROJECT_NUMBER         =
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "lalaala"
+PROJECT_BRIEF          = "Array index mapping tool for C language"
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55
@@ -710,6 +710,7 @@ ENABLED_SECTIONS       =
 # Minimum value: 0, maximum value: 10000, default value: 30.
 
 MAX_INITIALIZER_LINES  = 0
+
 # Set the SHOW_USED_FILES tag to NO to disable the list of files generated at
 # the bottom of the documentation of classes and structs. If set to YES, the
 # list will mention the files that were used to generate the documentation.

--- a/src/aimt.h
+++ b/src/aimt.h
@@ -10,8 +10,9 @@
  * then columns, then higher dimensions. The index starts from 1, and the subscripts start 
  * from (1, ..., 1).
  *
- * @param[in] arrayOfDimensions where each element represents the size of each array 
- * dimension. 
+ * @param[in] arrayOfDimensions where each element represents the is the size of the array 
+ * in the respective dimension.
+ *
  * @param[in] arrayOfSubscripts in which the set of its elements form the position to be 
  * converted.
  * @param[in] dimensions is size of the @paramname{arrayOfDimensions} and 
@@ -39,8 +40,8 @@
  * then columns, then higher dimensions. The index starts from 1, and the subscripts start 
  * from (1, ..., 1).
  *
- * @param[in] arrayOfDimensions where each element represents the number of rows and 
- * columns respectively.
+ * @param[in] arrayOfDimensions where each element represents the is the size of the array 
+ * in the respective dimension.
  * @param[in] dimensions is size of the @paramname{arrayOfDimensions} and 
  * @paramname{convertedIndex}.
  * @param[in] index to be converted.


### PR DESCRIPTION
In the Doxygen file, there was a strange description "lalala" and, the
explanation of the sub2ind and ind2sub macros only worked for the 2D
case. I fixed these problems.